### PR TITLE
Add a SEE ALSO section

### DIFF
--- a/lib/Smart/Comments.pm
+++ b/lib/Smart/Comments.pm
@@ -1059,6 +1059,11 @@ C<bug-smart-comments@rt.cpan.org>, or through the web interface at
 L<http://rt.cpan.org>.
 
 
+=head1 SEE ALSO
+
+L<Term::ProgressBar>, L<Term::ProgressBar::Simple>, L<Acme::ProgressBar>, L<Progress::Any::Output::TermProgressBarColor>
+
+
 =head1 REPOSITORY
 
 L<https://github.com/neilb/Smart-Comments>


### PR DESCRIPTION
As requested ( #1 ), I have added a SEE ALSO section. There are a myriad of progress bar modules, so I decided to restrict the modules linked to progress bars for the terminal instead of GUI or string based modules.

This PR is brought to you by the [PR Challenge](http://cpan-prc.org/).

PS: Sorry that it is late.
